### PR TITLE
internal: drop support for 1.9 and 1.10

### DIFF
--- a/internal/kokoro/test.sh
+++ b/internal/kokoro/test.sh
@@ -15,7 +15,9 @@ go version
 export GOPATH="$HOME/go"
 export GENPROTO_HOME=$GOPATH/src/google.golang.org/genproto
 export PATH="$GOPATH/bin:$PATH"
+export GO111MODULE=on
 mkdir -p $GENPROTO_HOME
+
 
 # Move code into $GOPATH and get dependencies
 git clone . $GENPROTO_HOME
@@ -23,19 +25,8 @@ cd $GENPROTO_HOME
 
 try3() { eval "$*" || eval "$*" || eval "$*"; }
 
-download_deps() {
-    if [[ `go version` == *"go1.11"* ]] || [[ `go version` == *"go1.12"* ]]; then
-        export GO111MODULE=on
-        # All packages, including +build tools, are fetched.
-        try3 go mod download
-    else
-        # Because we don't provide -tags tools, the +build tools
-        # dependencies aren't fetched.
-        try3 go get -v -t ./...
-    fi
-}
-
-download_deps
+# All packages, including +build tools, are fetched.
+try3 go mod download
 ./internal/kokoro/vet.sh
 
 # Run tests and tee output to log file, to be pushed to GCS as artifact.


### PR DESCRIPTION
As of Oct 1, 2019 GCP is no longer supporting Go 1.9 and 1.10.
Cleaning up build scripts to support this.