### PR TITLE
all: move from grpc.ClientConn to grpc. ClientConnInterface for files that are no longer generated

### DIFF
--- a/googleapis/cloud/bigquery/datatransfer/v1/datasource.pb.go
+++ b/googleapis/cloud/bigquery/datatransfer/v1/datasource.pb.go
@@ -1484,7 +1484,7 @@ var fileDescriptor_63170854e2f004ff = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -1551,10 +1551,10 @@ type DataSourceServiceClient interface {
 }
 
 type dataSourceServiceClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewDataSourceServiceClient(cc *grpc.ClientConn) DataSourceServiceClient {
+func NewDataSourceServiceClient(cc grpc.ClientConnInterface) DataSourceServiceClient {
 	return &dataSourceServiceClient{cc}
 }
 

--- a/googleapis/devtools/containeranalysis/v1/containeranalysis.pb.go
+++ b/googleapis/devtools/containeranalysis/v1/containeranalysis.pb.go
@@ -65,7 +65,7 @@ var fileDescriptor_e74edb4ed33b4f81 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -104,10 +104,10 @@ type ContainerAnalysisClient interface {
 }
 
 type containerAnalysisClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewContainerAnalysisClient(cc *grpc.ClientConn) ContainerAnalysisClient {
+func NewContainerAnalysisClient(cc grpc.ClientConnInterface) ContainerAnalysisClient {
 	return &containerAnalysisClient{cc}
 }
 

--- a/googleapis/grafeas/v1/grafeas.pb.go
+++ b/googleapis/grafeas/v1/grafeas.pb.go
@@ -1620,7 +1620,7 @@ var fileDescriptor_3546117bddf8439b = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -1666,10 +1666,10 @@ type GrafeasClient interface {
 }
 
 type grafeasClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewGrafeasClient(cc *grpc.ClientConn) GrafeasClient {
+func NewGrafeasClient(cc grpc.ClientConnInterface) GrafeasClient {
 	return &grafeasClient{cc}
 }
 


### PR DESCRIPTION
This is required to fully remove refs to gransport.Dial in gocloud.
These files were manually edited.

Updates: googleapis/google-cloud-go#1777