### PR TITLE
feat: Add helper methods for google.type.Date.

### DIFF
--- a/googleapis/type/date/date_helpers.go
+++ b/googleapis/type/date/date_helpers.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package date
+
+import "time"
+
+// ToLocalTime returns a new Time based on d, in the system's time zone.
+// Hours, minues, seconds, and nanoseconds are set to 0.
+func (d *Date) ToLocalTime() time.Time {
+	return d.ToTime(time.Local)
+}
+
+// ToUTCTime returns a new Time based on d, in UTC.
+// Hours, minutes, seconds, and nanoseconds are set to 0.
+func (d *Date) ToUTCTime() time.Time {
+	return d.ToTime(time.UTC)
+}
+
+// ToTime returns a new Time based on d and the provided *time.Location.
+// Hours, minutes, seconds, and nanoseconds are set to 0.
+func (d *Date) ToTime(l *time.Location) time.Time {
+	return time.Date(int(d.GetYear()), time.Month(d.GetMonth()), int(d.GetDay()), 0, 0, 0, 0, l)
+}
+
+// NewFromTime returns a new Date based on the provided time.Time.
+// The location is ignored, as is anything more precise than the day.
+func NewFromTime(t time.Time) *Date {
+	return &Date{
+		Year:  int32(t.Year()),
+		Month: int32(t.Month()),
+		Day:   int32(t.Day()),
+	}
+}

--- a/googleapis/type/date/date_helpers_test.go
+++ b/googleapis/type/date/date_helpers_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package date
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDate(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		y, m, d int
+	}{
+		{"NormalDate", 2012, 4, 21},
+		{"LongAgo", 1776, 7, 4},
+		{"Future", 2032, 4, 21},
+		{"FarFuture", 2062, 4, 21},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			datePb := &Date{Year: int32(test.y), Month: int32(test.m), Day: int32(test.d)}
+			times := map[string]time.Time{
+				"local": datePb.ToLocalTime(),
+				"utc":   datePb.ToUTCTime(),
+			}
+			for k, time := range times {
+				t.Run(k, func(t *testing.T) {
+					assertEqual(t, "year", time.Year(), test.y)
+					assertEqual(t, "month", int(time.Month()), test.m)
+					assertEqual(t, "day", time.Day(), test.d)
+					dtPb := NewFromTime(time)
+					t.Run("ToProto", func(t *testing.T) {
+						assertEqual(t, "year", dtPb.GetYear(), int32(test.y))
+						assertEqual(t, "month", dtPb.GetMonth(), int32(test.m))
+						assertEqual(t, "day", dtPb.GetDay(), int32(test.d))
+					})
+				})
+			}
+		})
+	}
+}
+
+func assertEqual(t *testing.T, name string, got, want interface{}) {
+	t.Run(name, func(t *testing.T) {
+		if got != want {
+			t.Errorf("Got %v, expected %v.", got, want)
+		}
+	})
+}


### PR DESCRIPTION
@noahdietz @codyoss 

I have been working for the past couple days on a helper library for the common protobuf types in Go. And, it occurred to me, I wonder if we can actually put them in genproto, where we could essentially add methods on the proto message structs themselves?

This PR represents what that could look like for the `google.type.Date` class. I have similar helpers queued up for `Color`, `DateTime`, and `Fraction`, and I very much want to do `Decimal` (just introduced).

Curious:

- Will this even work? Will autogeneration just nuke it into powder next time it runs?
- Is it desirable? (I think it is.)