### PR TITLE
chore(ci): add apidiff to GitHub Actions

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -11,9 +11,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: main
-    - uses: actions/setup-go@v3
-    - name: Install latest apidiff
-      run: go install golang.org/x/exp/cmd/apidiff@latest
     - name: Create Go package baseline
       run: apidiff -w pkg.main google.golang.org/genproto
     - uses: actions/checkout@v3

--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -1,0 +1,21 @@
+---
+name: apidiff
+on:
+  pull_request:
+
+jobs:
+  apidiff:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: main
+    - uses: actions/setup-go@v3
+    - name: Install latest apidiff
+      run: go install golang.org/x/exp/cmd/apidiff@latest
+    - name: Create Go package baseline
+      run: apidiff -w pkg.main google.golang.org/genproto
+    - uses: actions/checkout@v3
+    - name: Compare regenerated code to baseline
+      run: apidiff -incompatible pkg.main google.golang.org/genproto > diff.txt && cat diff.txt && ! [ -s diff.txt ]


### PR DESCRIPTION
Adds execution of `apidiff` to `go-genproto` which can be disabled with the (proposed) label `breaking change allowed`.

Fixes b/235517117