### PR TITLE
chore(ci): apidiff diff filter deleted, modified, renamed

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Get changed directories
       id: changed_dirs
       run: |
-        dirs=$(git diff-tree --no-commit-id --name-only --diff-filter=ACMR -r ${{ steps.main.outputs.hash }}..HEAD | grep googleapis/ | xargs -r -L1 dirname | uniq)
+        dirs=$(git diff-tree --no-commit-id --name-only --diff-filter=DMR -r ${{ steps.main.outputs.hash }}..HEAD | grep googleapis/ | xargs -r -L1 dirname | uniq)
         if [ -z "$dirs" ]
         then
           echo "::set-output name=changed::{\"changed\":[]}"


### PR DESCRIPTION
Switch the `diff-filter` to D(eleted) M(odified) R(enamed). Adding new/copying existing files is not a breaking change, and don't need to be checked.

Note: If an entire package is removed, the package-specific job will be triggered and `apidiff` will fail because there is no package anymore - this is a sufficient failure to communicate that there was a breaking change imo.

Fixes #851 