### PR TITLE
chore: update mod version to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,15 @@
 module google.golang.org/genproto
 
-go 1.15
+go 1.17
 
 require (
 	github.com/golang/protobuf v1.5.2
+	google.golang.org/grpc v1.47.0
+	google.golang.org/protobuf v1.28.0
+)
+
+require (
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.5 // indirect
-	google.golang.org/grpc v1.47.0
-	google.golang.org/protobuf v1.28.0
 )


### PR DESCRIPTION
By declaring 1.17 we enable downstream consumers this module to
take advantage of mod graph pruning and lazy loading of modules. We
still support older versions, but this is just nice for our users
that are declaring a newer version in their module.

Fixes: #858