### PR TITLE
fix(dataform): Remove broken aliases

### DIFF
--- a/googleapis/cloud/dataform/v1beta1/alias.go
+++ b/googleapis/cloud/dataform/v1beta1/alias.go
@@ -134,11 +134,6 @@ type CompilationResultAction_Relation_IncrementalTableConfig = src.CompilationRe
 // Deprecated: Please use types in: cloud.google.com/go/dataform/apiv1beta1/dataformpb
 type CompilationResultAction_Relation_RelationType = src.CompilationResultAction_Relation_RelationType
 
-// Configures various aspects of Dataform code compilation.
-//
-// Deprecated: Please use types in: cloud.google.com/go/dataform/apiv1beta1/dataformpb
-type CompilationResult_CodeCompilationConfig = src.CompilationResult_CodeCompilationConfig
-
 // An error encountered when attempting to compile a Dataform project.
 //
 // Deprecated: Please use types in: cloud.google.com/go/dataform/apiv1beta1/dataformpb
@@ -373,13 +368,6 @@ type QueryDirectoryContentsRequest = src.QueryDirectoryContentsRequest
 // Deprecated: Please use types in: cloud.google.com/go/dataform/apiv1beta1/dataformpb
 type QueryDirectoryContentsResponse = src.QueryDirectoryContentsResponse
 
-// Represents a single entry in a workspace directory.
-//
-// Deprecated: Please use types in: cloud.google.com/go/dataform/apiv1beta1/dataformpb
-type QueryDirectoryContentsResponse_DirectoryEntry = src.QueryDirectoryContentsResponse_DirectoryEntry
-type QueryDirectoryContentsResponse_DirectoryEntry_Directory = src.QueryDirectoryContentsResponse_DirectoryEntry_Directory
-type QueryDirectoryContentsResponse_DirectoryEntry_File = src.QueryDirectoryContentsResponse_DirectoryEntry_File
-
 // `QueryWorkflowInvocationActions` request message.
 //
 // Deprecated: Please use types in: cloud.google.com/go/dataform/apiv1beta1/dataformpb
@@ -476,13 +464,6 @@ type WorkflowInvocationAction_BigQueryAction = src.WorkflowInvocationAction_BigQ
 //
 // Deprecated: Please use types in: cloud.google.com/go/dataform/apiv1beta1/dataformpb
 type WorkflowInvocationAction_State = src.WorkflowInvocationAction_State
-
-// Includes various configuration options for this workflow invocation. If
-// both `included_targets` and `included_tags` are unset, all actions will be
-// included.
-//
-// Deprecated: Please use types in: cloud.google.com/go/dataform/apiv1beta1/dataformpb
-type WorkflowInvocation_InvocationConfig = src.WorkflowInvocation_InvocationConfig
 
 // Represents the current state of a workflow invocation.
 //


### PR DESCRIPTION
*pb.go files for dataform were migrated from go-genproto repo to google-cloud-go. Although the type definitions have moved, aliases have been left in the old genproto packages to ensure a smooth non-breaking transition.

But some type definitions have been removed in this commit: https://github.com/googleapis/google-cloud-go/pull/8749

For e.g. CompilationResult_CodeCompilationConfig https://github.com/googleapis/go-genproto/pull/1080/files#diff-3b7ca78e146cf9f4aad33eee3ec8ffb855b5384a0c7d3e8dabd4987e21c125cbL137-L141 is alias for CompilationResult_CodeCompilationConfig https://github.com/googleapis/google-cloud-go/blob/fcb41cc1d2435452ee78314c1b0362e3f21ae637/dataform/apiv1beta1/dataformpb/dataform.pb.go#L4508 but this type definition was removed in above PR

Removing the broken aliases in this PR