### PR TITLE
chore: fix kokoro with safedir for git

### DIFF
--- a/internal/kokoro/test.sh
+++ b/internal/kokoro/test.sh
@@ -8,6 +8,7 @@ set -x
 
 # cd to project dir on Kokoro instance
 cd github/go-genproto
+git config --global --add safe.directory "$(pwd)/./.git"
 
 go version
 


### PR DESCRIPTION
Fixes kokoro error:

```sh
+ git clone . /root/go/src/google.golang.org/genproto
Cloning into '/root/go/src/google.golang.org/genproto'...
fatal: detected dubious ownership in repository at '/tmpfs/src/github/go-genproto/./.git'
To add an exception for this directory, call:

	git config --global --add safe.directory /tmpfs/src/github/go-genproto/./.git
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```