### PR TITLE
Fix: GitHub workflow script injection

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -3,6 +3,9 @@ name: apidiff
 on:
   pull_request:
 
+env:
+  PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+
 jobs:
   scan_changes:
     runs-on: ubuntu-latest
@@ -76,7 +79,7 @@ jobs:
       # non-breaking.
       run: |
         cd ${{ matrix.changed }} && apidiff -m -incompatible ${{ steps.baseline.outputs.pkg }} . > diff.txt
-        if [[ ${{ github.event.pull_request.head.ref }} == owl-bot-copy ]]; then
+        if [[ $PR_HEAD_REF == owl-bot-copy ]]; then
           sed -i '/: added/d' ./diff.txt
         fi
         cat diff.txt && ! [ -s diff.txt ]


### PR DESCRIPTION
Hi! Joyce from [Google's Open Source Security Team (GOSST)](https://opensource.googleblog.com/2023/04/googles-open-source-security-upstream-team-one-year-later.html) here. This PR prevents script injection in your GitHub workflows by parsing github.event.pull_request.head.ref into an environment variable before use.

More info on this threat: [Keeping your GitHub Actions and workflows secure Part 2: Untrusted input](https://securitylab.github.com/resources/github-actions-untrusted-input/).

Any questions, let me know!

Thanks!