### PR TITLE
fix(dialogflow/v2beta1): remove orphaned alias

### DIFF
--- a/googleapis/cloud/dialogflow/v2beta1/alias.go
+++ b/googleapis/cloud/dialogflow/v2beta1/alias.go
@@ -1180,12 +1180,6 @@ type GetVersionRequest = src.GetVersionRequest
 // Deprecated: Please use types in: cloud.google.com/go/dialogflow/apiv2beta1/dialogflowpb
 type HumanAgentAssistantConfig = src.HumanAgentAssistantConfig
 
-// Custom conversation models used in agent assist feature. Supported feature:
-// ARTICLE_SUGGESTION, SMART_COMPOSE, SMART_REPLY, CONVERSATION_SUMMARIZATION.
-//
-// Deprecated: Please use types in: cloud.google.com/go/dialogflow/apiv2beta1/dialogflowpb
-type HumanAgentAssistantConfig_ConversationModelConfig = src.HumanAgentAssistantConfig_ConversationModelConfig
-
 // Config to process conversation.
 //
 // Deprecated: Please use types in: cloud.google.com/go/dialogflow/apiv2beta1/dialogflowpb


### PR DESCRIPTION
dialogflow made a breaking change that removed an existing message. This PR removes the alias to that message which no longer resolves.

Related: https://github.com/googleapis/googleapis/commit/e9195b36c9896e43fc9fa38793b66b5cf1d59b50