### PR TITLE
chore: add permission constraints to github actions

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -3,6 +3,9 @@ name: apidiff
 on:
   pull_request:
 
+permissions:
+    contents: read
+
 env:
   PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
 


### PR DESCRIPTION
We're getting zizmor audit failures related to a lack of explicit permissions.